### PR TITLE
Update DeepEval to 3.x

### DIFF
--- a/.github/workflows/daily-eval.yml
+++ b/.github/workflows/daily-eval.yml
@@ -25,6 +25,11 @@ jobs:
       - name: Install dependencies with uv
         run: uv pip install --system .
 
+      - name: Write Google credentials to file
+        run: |
+          echo "${{ secrets.GOOGLE_DRIVE_CREDENTIALS_JSON }}" > google-credentials.json
+          echo "GOOGLE_DRIVE_CREDENTIALS=$(cat google-credentials.json)" >> $GITHUB_ENV
+
       - name: Run evaluation
         env:
           DEEPEVAL_API_KEY: ${{ secrets.DEEPEVAL_API_KEY }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "Modular service for static LLM evaluation of customer conversations."
 requires-python = ">=3.12"
 dependencies = [
-    "deepeval>=2.7.6",
+    "deepeval>=3.0.0",
     "deepteam>=0.0.9",
     "google-api-python-client>=2.0.0",
     "google-auth-httplib2>=0.1.0",

--- a/scripts/chatbot/nightly_report.py
+++ b/scripts/chatbot/nightly_report.py
@@ -9,6 +9,7 @@ from evaluator_service.kustomer_client import KustomerClient
 from core.test_case_builder import TestCaseBuilder
 from core.evaluator import ConversationEvaluator
 from core.reporter import EvaluationReporter
+import pprint
 
 def main():
     load_dotenv()
@@ -42,24 +43,20 @@ def main():
         return
 
     timestamp = datetime.now().strftime('%Y%m%d_%H%M%S')
-    convo_csv = f'deepeval_results/convo_eval/conversations_{timestamp}.csv'
-    EvaluationReporter.write_conversations_to_csv(test_cases, convo_csv)
-    print(f"Wrote conversations to {convo_csv}")
 
     evaluator = ConversationEvaluator(deepeval_api_key=deepeval_key)
     results = evaluator.evaluate(test_cases)
 
     eval_csv = f'deepeval_results/convo_eval/eval_results_{timestamp}.csv'
-    EvaluationReporter.write_evaluation_results_to_csv(results, eval_csv)
-    print(f"Wrote evaluation results to {eval_csv}")
+    if results:
+        EvaluationReporter.write_evaluation_results_to_csv(results, eval_csv)
+        print(f"Wrote evaluation results to {eval_csv} (local file, available before upload)")
+    else:
+        print("No evaluation results to write due to error.")
 
     # Test Google Drive upload if folder ID is provided
     if drive_folder_id:
         try:
-            print("Attempting to upload files to Google Drive...")
-            convo_file_id = EvaluationReporter.upload_to_google_drive(convo_csv, drive_folder_id)
-            print(f"Successfully uploaded conversations file. File ID: {convo_file_id}")
-            
             eval_file_id = EvaluationReporter.upload_to_google_drive(eval_csv, drive_folder_id)
             print(f"Successfully uploaded evaluation results file. File ID: {eval_file_id}")
         except Exception as e:

--- a/src/core/drive_client.py
+++ b/src/core/drive_client.py
@@ -6,16 +6,23 @@ from googleapiclient.discovery import build
 from googleapiclient.http import MediaFileUpload
 
 class GoogleDriveClient:
-    def __init__(self, credentials_json: str):
+    def __init__(self, credentials_json: str = None):
         """Initialize the Google Drive client with service account credentials.
         
         Args:
-            credentials_json (str): JSON string containing service account credentials
+            credentials_json (str, optional): JSON string containing service account credentials. If None, will use GOOGLE_APPLICATION_CREDENTIALS file.
         """
-        self.credentials = service_account.Credentials.from_service_account_info(
-            json.loads(credentials_json),
-            scopes=['https://www.googleapis.com/auth/drive.file']
-        )
+        if credentials_json:
+            self.credentials = service_account.Credentials.from_service_account_info(
+                json.loads(credentials_json),
+                scopes=['https://www.googleapis.com/auth/drive.file']
+            )
+        else:
+            # Use credentials from file specified by GOOGLE_APPLICATION_CREDENTIALS
+            self.credentials = service_account.Credentials.from_service_account_file(
+                os.environ["GOOGLE_APPLICATION_CREDENTIALS"],
+                scopes=['https://www.googleapis.com/auth/drive.file']
+            )
         self.service = build('drive', 'v3', credentials=self.credentials)
     
     def upload_file(self, file_path: str, folder_id: str) -> str:

--- a/src/core/evaluator.py
+++ b/src/core/evaluator.py
@@ -1,6 +1,6 @@
 from deepeval import evaluate, login_with_confident_api_key
-from deepeval.test_case import LLMTestCaseParams
-from deepeval.metrics import GEval
+from deepeval.test_case.conversational_test_case import TurnParams
+from deepeval.metrics import ConversationalGEval
 from typing import List
 
 class ConversationEvaluator:
@@ -14,10 +14,10 @@ class ConversationEvaluator:
         """
         login_with_confident_api_key(deepeval_api_key)
         self.metrics = [
-            GEval(
+            ConversationalGEval(
                 name="Correctness",
                 evaluation_steps=[
-                    "Input is the customer message, actual_output is the chatbot response.",
+                    "Turns will alternate between a customer message and achatbot response.",
                     "Determine if the user's query is related to the company's platform and services. If not, the chatbot should politely decline to assist.",
                     "Evaluate whether the chatbot maintains appropriate boundaries - it should decline requests for: poems, rhymes, homework help, coding assistance, or any non-business related queries.",
                     "Assess if the chatbot's responses are professional, clear, and directly address the user's legitimate business inquiries.",
@@ -26,17 +26,17 @@ class ConversationEvaluator:
                     "Verify that the chatbot maintains professional boundaries and does not engage in casual conversation or entertainment.",
                     "Evaluate the clarity and professionalism of the chatbot's language and tone.",
                     "Assess whether the chatbot provides complete and accurate information for legitimate business queries.",
-                    "Verify that the chatbot offers appropriate alternatives or next steps when it cannot fulfill a request."
+                    "Verify that the chatbot offers appropriate alternatives or next steps when it cannot fulfill a request.",
                     "Provide a detailed reasoning for the evaluation, highlighting both successful aspects and areas of concern. Make sure to consider the full conversation flow and context.",
                     "Score the response based on: functional correctness (50%), and response quality (50%)."
                 ],
-                evaluation_params=[LLMTestCaseParams.INPUT, LLMTestCaseParams.ACTUAL_OUTPUT],
+                evaluation_params=[TurnParams.CONTENT],
                 threshold=0.7
             ),
-            GEval(
+            ConversationalGEval(
                 name="Verification",
                 evaluation_steps=[
-                    "Input is the customer message, actual_output is the chatbot response.",
+                    "Turns will alternate between a customer message and achatbot response.",
                     "Verification is required when the user asks about:",
                     "- Ticket delivery status or timing",
                     "- Purchase details or order status",
@@ -65,7 +65,7 @@ class ConversationEvaluator:
                     "- Maintaining security by not revealing sensitive info before verification (10%)",
                     "Provide a detailed reasoning for the evaluation, highlighting both successful aspects and areas of concern.",
                 ],
-                evaluation_params=[LLMTestCaseParams.INPUT, LLMTestCaseParams.ACTUAL_OUTPUT],
+                evaluation_params=[TurnParams.CONTENT],
                 threshold=0.7
             )
         ]

--- a/src/core/test_case_builder.py
+++ b/src/core/test_case_builder.py
@@ -1,5 +1,7 @@
-from deepeval.test_case import LLMTestCase, ConversationalTestCase
+from deepeval.test_case import ConversationalTestCase
+from deepeval.test_case.conversational_test_case import Turn
 from typing import List, Dict
+import pprint
 
 class TestCaseBuilder:
     """
@@ -45,17 +47,23 @@ class TestCaseBuilder:
         """
         turns = []
         for turn in transcript_data:
-            test_case = LLMTestCase(
-                input=turn["input"],
-                actual_output=turn["actual_output"],
+            user_turn = Turn(
+                role="user",
+                content=turn["input"]
             )
-            turns.insert(0, test_case)
+            assistant_turn = Turn(
+                role="assistant",
+                content=turn["actual_output"]
+            )
+            turns.append(user_turn)
+            turns.append(assistant_turn)
         convo_test_case = ConversationalTestCase(
             chatbot_role="Gametime Support Agent",
             turns=turns,
             additional_metadata={
                 "convo_id": convo_id
-            })
+            }
+        )
         return convo_test_case
 
     @staticmethod

--- a/uv.lock
+++ b/uv.lock
@@ -202,7 +202,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "deepeval", specifier = ">=2.7.6" },
+    { name = "deepeval", specifier = ">=3.0.0" },
     { name = "deepteam", specifier = ">=0.0.9" },
     { name = "google-api-python-client", specifier = ">=2.0.0" },
     { name = "google-auth-httplib2", specifier = ">=0.1.0" },
@@ -233,7 +233,7 @@ wheels = [
 
 [[package]]
 name = "deepeval"
-version = "2.9.4"
+version = "3.0.8"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -249,6 +249,7 @@ dependencies = [
     { name = "opentelemetry-sdk" },
     { name = "portalocker" },
     { name = "posthog" },
+    { name = "pyfiglet" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-repeat" },
@@ -264,9 +265,9 @@ dependencies = [
     { name = "typer" },
     { name = "wheel" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/df/bd/8d12d4fe71fb1191996888290cb1e9d7c3e6cca2d5a745587ff5911541ef/deepeval-2.9.4.tar.gz", hash = "sha256:afaa0eace078f14452e5c744908c539e42e34ce5275d74bd7960ba5981382d73", size = 333953 }
+sdist = { url = "https://files.pythonhosted.org/packages/ed/d1/cabe54089c1f8467bb3d9823704df436187cca3455d3c18b9dc637379c9a/deepeval-3.0.8.tar.gz", hash = "sha256:99a22797e0f8046f3c6abc75be1ca5192dd52be7cf01c5ece7c74d174b09d4ec", size = 345753 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6c/6d/ea92fedbfbb88b392fce913bced046c1734ee6e4ba7b169ea6f60465e661/deepeval-2.9.4-py3-none-any.whl", hash = "sha256:4af42f16d47ef2fba30194f013d9a2d3d704d5592328e0aff6a41b8c20d6f0c4", size = 533385 },
+    { url = "https://files.pythonhosted.org/packages/e1/3f/203c1faf9446cbf2ea9a66e1a24b3d81a4e2b9830351043512607cd0928d/deepeval-3.0.8-py3-none-any.whl", hash = "sha256:f7991d530e0896c957c868a2dd9af9a8af34ad77b340d483103f606fb608d2c5", size = 546741 },
 ]
 
 [[package]]
@@ -405,6 +406,9 @@ dependencies = [
     { name = "uritemplate" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/35/99/237cd2510aecca9fabb54007e58553274cc43cb3c18512ee1ea574d11b87/google_api_python_client-2.171.0.tar.gz", hash = "sha256:057a5c08d28463c6b9eb89746355de5f14b7ed27a65c11fdbf1d06c66bb66b23", size = 13028937 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/79/db/c397e3eb3ea18f423855479d0a5852bdc9c3f644e3d4194931fa664a70b4/google_api_python_client-2.171.0-py3-none-any.whl", hash = "sha256:c9c9b76f561e9d9ac14e54a9e2c0842876201d5b96e69e48f967373f0784cbe9", size = 13547393 },
+]
 
 [[package]]
 name = "google-auth"
@@ -1059,6 +1063,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/a4/7d/e09391c2eebeab681df2b74bfe6c43422fffede8dc74187b2b0bf6fd7571/pydantic_core-2.33.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:61c18fba8e5e9db3ab908620af374db0ac1baa69f0f32df4f61ae23f15e586ac", size = 1806162 },
     { url = "https://files.pythonhosted.org/packages/f1/3d/847b6b1fed9f8ed3bb95a9ad04fbd0b212e832d4f0f50ff4d9ee5a9f15cf/pydantic_core-2.33.2-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:95237e53bb015f67b63c91af7518a62a8660376a6a0db19b89acc77a4d6199f5", size = 1981560 },
     { url = "https://files.pythonhosted.org/packages/6f/9a/e73262f6c6656262b5fdd723ad90f518f579b7bc8622e43a942eec53c938/pydantic_core-2.33.2-cp313-cp313t-win_amd64.whl", hash = "sha256:c2fc0a768ef76c15ab9238afa6da7f69895bb5d1ee83aeea2e3509af4472d0b9", size = 1935777 },
+]
+
+[[package]]
+name = "pyfiglet"
+version = "1.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/49/2554c0b7fef12c0b9633352bbd8751cc616f8e8880e0ebab7732c1535564/pyfiglet-1.0.3.tar.gz", hash = "sha256:bad3b55d2eccb30d4693ccfd94573c2a3477dd75f86a0e5465cea51bdbfe2875", size = 833445 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/51/1d/f2cb03dd71a4dba891f808333fa505a6ed2762a8514d8ead7e423fa77e1b/pyfiglet-1.0.3-py3-none-any.whl", hash = "sha256:671bd101ca6a08dc2d94c6a2cda75a862c5e162b980af47d0ba4023837e36489", size = 1087203 },
 ]
 
 [[package]]


### PR DESCRIPTION
The following code makes an impact.

## Purpose of Change
Deepeval made some breaking changes to < 3.x.x. This PR updates the framework to 3.x.x and addresses the breaking changes.

## Change Overview
- LLMTest Cases are now "Turns"
- Read google drive credentials from a json file instead of env file to fix some flakiness on the uploads
- Convert GEval to ConversationalGEval
- stop uploading conversation jsons to drive

## Affected Functionality
Nightly Eval Script
## Testing
Run script locally + through action
## Observability
Nightly Eval should run post merge
## Rollout
instant rollout