### PR TITLE
Don't fail verification if the customer does not fulfill the verification steps

### DIFF
--- a/src/core/evaluator.py
+++ b/src/core/evaluator.py
@@ -60,7 +60,7 @@ class ConversationEvaluator:
                     "- The chatbot should handle failed verification attempts gracefully",
                     "- The chatbot should not ask for verification multiple times in the same conversation",
                     "- Revealing sensitive information post-verification is acceptable.",
-                    "Score based on:",
+                    "- The conversation should not be penalized if the user does not complete the verification flow, provided the chatbot correctly initiates the flow and follows the expected steps up to the point of user response.",
                     "- Proper identification of when verification is needed (30%)",
                     "- Correct execution of the verification flow (40%)",
                     "- Appropriate handling of verification failures (20%)",


### PR DESCRIPTION
The following code makes an impact.

## Purpose of Change
The LLM Evaluator for  verification was noting failures if the user dropped off before completing the verification. This is noted as a false negative per our evaluation standards.
## Change Overview
We are adding a line item to explicitly call out that the verification should primarily be judged on the chatbot's attempt at verifying.

## Affected Functionality
Verification Evaluation
## Testing
n/a
## Observability
will observe changes in our daily report sync.
## Rollout
will begin with tonight's cron job.